### PR TITLE
Add `sd_product` tag to auto-gen pr. layout

### DIFF
--- a/layouts/auto_generated_product.tpl
+++ b/layouts/auto_generated_product.tpl
@@ -9,6 +9,8 @@
   {% include "html-head" sidebar: true %}
   {% include "template-styles" %}
   {% include "common-page-variables" %}
+
+  {% sd_product %}
 </head>
 
 {%- capture bottom_content_html %}


### PR DESCRIPTION
Include `sd_product` tag in Auto-rendered Product layout to render out product structured data.

Closes #24 